### PR TITLE
Excluded test domain classes from generated META-INF/grails-plugin.xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,3 +78,7 @@ bintray {
         vcsUrl = "https://github.com/piotrchowaniec/$project.name"
     }
 }
+
+jar {   
+	exclude "test/**"
+}

--- a/src/main/groovy/org.grails.plugin.hibernate.filter/HibernateFilterGrailsPlugin.groovy
+++ b/src/main/groovy/org.grails.plugin.hibernate.filter/HibernateFilterGrailsPlugin.groovy
@@ -13,7 +13,7 @@ class HibernateFilterGrailsPlugin extends Plugin
 	def grailsVersion = "3.0.3 > *"
 	def loadAfter = ['controllers', 'hibernate']
 	def observe = ['*']
-	def pluginExcludes = ['grails-app/domain/**']
+	def pluginExcludes = ['test/**']
 
 	def author = 'Scott Burch'
 	def authorEmail = 'scott@bulldoginfo.com'


### PR DESCRIPTION
The Foo/Foo2/Bar domain classes were being created as resources in the applications using the plugin. I have corrected the pluginExcludes path and added the jar exclusion to build.gradle, as per https://github.com/grails/grails-core/issues/9416.
